### PR TITLE
Improved README.md to mention important detail.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ run.Group is a universal mechanism to manage goroutine lifecycles.
 Create a zero-value run.Group, and then add actors to it. Actors are defined as
 a pair of functions: an **execute** function, which should run synchronously;
 and an **interrupt** function, which, when invoked, should cause the execute
-function to return. Finally, invoke Run, which blocks until the first actor
-returns. This general-purpose API allows callers to model pretty much any
-runnable task, and achieve well-defined lifecycle semantics for the group.
+function to return. Finally, invoke Run, which runs concurrently all the actors 
+until any of them returns. In that case, interrupt is invoked for all actors and Run 
+waits for all of them to exit. This general-purpose API allows callers to model pretty 
+much any runnable task, and achieve well-defined lifecycle semantics for the group.
 
 run.Group was written to manage component lifecycles in func main for 
 [OK Log](https://github.com/oklog/oklog). 


### PR DESCRIPTION
I think that sentence is not really true or at least can be confusing:
> Finally, invoke Run, which blocks until the first actor returns. 

We wanted to use this awesome package as recommended way of handling concurrent workers, but actually someone was saying that `oklog/run` is not waiting until all go routines exit. 0.o I knew it is not leaking any go routines, but actually the README caused that confusion. I guess it can mislead.

Comment for `Run` method actually states things properly :+1:

PTAL @peterbourgon 