### PR TITLE
Deregister signal channel

### DIFF
--- a/actors.go
+++ b/actors.go
@@ -15,6 +15,7 @@ func SignalHandler(ctx context.Context, signals ...os.Signal) (execute func() er
 	return func() error {
 			c := make(chan os.Signal, 1)
 			signal.Notify(c, signals...)
+			defer signal.Stop(c)
 			select {
 			case sig := <-c:
 				return SignalError{Signal: sig}


### PR DESCRIPTION
If `SignalHandler` is being used as a mechanism to exit the program entirely, these resources will be cleaned up naturally. But if not, the signal should be explicitly deregistered.

Make sure the channel is eligible to be garbage collected and that no additional signals should be delivered to the channel after this actor exits.

See also: https://go-review.googlesource.com/c/go/+/219640/2/src/context/context.go#543