### PR TITLE
feat: add ContextHandler as a separate helper function

### DIFF
--- a/actors.go
+++ b/actors.go
@@ -9,7 +9,8 @@ import (
 
 // SignalHandler returns an actor, i.e. an execute and interrupt func, that
 // terminates with SignalError when the process receives one of the provided
-// signals, or the parent context is canceled.
+// signals, or the parent context is canceled. If no signals are provided,
+// handler will listen for all incoming signals.
 func SignalHandler(ctx context.Context, signals ...os.Signal) (execute func() error, interrupt func(error)) {
 	ctx, cancel := context.WithCancel(ctx)
 	return func() error {

--- a/actors.go
+++ b/actors.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ContextHandler returns an actor, i.e. an execute and interrupt func, that
-// terminates with when the parent context is canceled.
+// terminates when the provided context is canceled.
 func ContextHandler(ctx context.Context) (execute func() error, interrupt func(error)) {
 	ctx, cancel := context.WithCancel(ctx)
 	return func() error {
@@ -22,7 +22,7 @@ func ContextHandler(ctx context.Context) (execute func() error, interrupt func(e
 // SignalHandler returns an actor, i.e. an execute and interrupt func, that
 // terminates with SignalError when the process receives one of the provided
 // signals, or the parent context is canceled. If no signals are provided,
-// handler will listen for all incoming signals.
+// the actor will terminate on any signal, per [signal.Notify].
 func SignalHandler(ctx context.Context, signals ...os.Signal) (execute func() error, interrupt func(error)) {
 	ctx, cancel := context.WithCancel(ctx)
 	return func() error {

--- a/actors.go
+++ b/actors.go
@@ -9,7 +9,7 @@ import (
 
 // ContextHandler returns an actor, i.e. an execute and interrupt func, that
 // terminates with when the parent context is canceled.
-func ContextHandler(ctx context.Context, signals ...os.Signal) (execute func() error, interrupt func(error)) {
+func ContextHandler(ctx context.Context) (execute func() error, interrupt func(error)) {
 	ctx, cancel := context.WithCancel(ctx)
 	return func() error {
 			<-ctx.Done()

--- a/actors.go
+++ b/actors.go
@@ -7,6 +7,18 @@ import (
 	"os/signal"
 )
 
+// ContextHandler returns an actor, i.e. an execute and interrupt func, that
+// terminates with when the parent context is canceled.
+func ContextHandler(ctx context.Context, signals ...os.Signal) (execute func() error, interrupt func(error)) {
+	ctx, cancel := context.WithCancel(ctx)
+	return func() error {
+			<-ctx.Done()
+			return ctx.Err()
+		}, func(error) {
+			cancel()
+		}
+}
+
 // SignalHandler returns an actor, i.e. an execute and interrupt func, that
 // terminates with SignalError when the process receives one of the provided
 // signals, or the parent context is canceled. If no signals are provided,


### PR DESCRIPTION
SignalHandler doesn't work the way it was written in docs. It listens for all signals if none is provided.

I decided not to change it for backward compatibility, but to add this important detail about its behaviour. I also added a separate helper function `ContextHandler` which helps to stop Groups with context.