### PR TITLE
README: add gracefully shutdown http server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # run
 
-[![GoDoc](https://godoc.org/github.com/oklog/run?status.svg)](https://godoc.org/github.com/oklog/run) 
+[![GoDoc](https://godoc.org/github.com/oklog/run?status.svg)](https://godoc.org/github.com/oklog/run)
 [![test](https://github.com/oklog/run/actions/workflows/test.yaml/badge.svg?branch=main&event=push)](https://github.com/oklog/run/actions/workflows/test.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/oklog/run)](https://goreportcard.com/report/github.com/oklog/run)
 [![Apache 2 licensed](https://img.shields.io/badge/license-Apache2-blue.svg)](https://raw.githubusercontent.com/oklog/run/master/LICENSE)
@@ -16,8 +16,8 @@ finally returns control to the caller only once all actors have returned. This
 general-purpose API allows callers to model pretty much any runnable task, and
 achieve well-defined lifecycle semantics for the group.
 
-run.Group was written to manage component lifecycles in func main for 
-[OK Log](https://github.com/oklog/oklog). 
+run.Group was written to manage component lifecycles in func main for
+[OK Log](https://github.com/oklog/oklog).
 But it's useful in any circumstance where you need to orchestrate multiple
 goroutines as a unit whole.
 [Click here](https://www.youtube.com/watch?v=LHe1Cb_Ud_M&t=15m45s) to see a
@@ -62,14 +62,31 @@ g.Add(func() error {
 })
 ```
 
+### Gracefully shutdown HTTP server
+```go
+g := &run.Group{}
+g.Add(run.SignalHandler(context.Background(), syscall.SIGINT, syscall.SIGTERM))
+srv := &http.Server{}
+g.Add(func() error {
+	log.Printf("starting server")
+	return srv.ListenAndServe()
+}, func(err error) {
+	log.Printf("shutting down server")
+	shutdownErr := srv.Shutdown(context.Background())
+	log.Printf("shutdown err: %v", shutdownErr)
+})
+err := g.Run()
+log.Printf("run err: %v", err)
+```
+
 ## Comparisons
 
-Package run is somewhat similar to package 
-[errgroup](https://godoc.org/golang.org/x/sync/errgroup), 
+Package run is somewhat similar to package
+[errgroup](https://godoc.org/golang.org/x/sync/errgroup),
 except it doesn't require actor goroutines to understand context semantics.
 
 It's somewhat similar to package
-[tomb.v1](https://godoc.org/gopkg.in/tomb.v1) or 
+[tomb.v1](https://godoc.org/gopkg.in/tomb.v1) or
 [tomb.v2](https://godoc.org/gopkg.in/tomb.v2),
-except it has a much smaller API surface, delegating e.g. staged shutdown of 
+except it has a much smaller API surface, delegating e.g. staged shutdown of
 goroutines to the caller.


### PR DESCRIPTION
`run` provides a good way to write a gracefully shutting down HTTP server. It also provides a `SignalHandler` to make it more elegant. So I want to add this example in the Readme.
 
# What's changed
- Delete some trailing whitespace in the Readme
- Add gracefully shutdown http server example